### PR TITLE
Resolve npm name collision.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azimuth",
+  "name": "urbit-azimuth",
   "version": "0.9.0",
   "description": "A general-purpose PKI on the Ethereum blockchain.",
   "main": "truffle.js",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
   "name": "urbit-azimuth",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A general-purpose PKI on the Ethereum blockchain.",
   "main": "truffle.js",
   "directories": {
-    "doc": "docs",
     "test": "test"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "babel-register": "^6.26.0",
     "openzeppelin-solidity": "1.10.0",
-    "solidity-coverage": "^0.5.4",
-    "truffle": "4.1.11",
-    "web3-eth-abi": "^1.0.0-beta.34"
+    "truffle": "4.1.11"
   },
   "devDependencies": {
     "ganache-cli": "^6.1.8",
     "mocha": "^5.2.0",
-    "npm-run-all": "^4.1.3"
+    "npm-run-all": "^4.1.3",
+    "web3-eth-abi": "^1.0.0-beta.34",
+    "solidity-coverage": "^0.5.4"
   },
+  "bundledDependencies": [
+    "openzeppelin-solidity"
+  ],
   "scripts": {
     "build": "truffle compile",
     "test:ganache": "ganache-cli --gasLimit 6000000 > /dev/null &",
@@ -32,7 +32,7 @@
     "type": "git",
     "url": "git+https://github.com/urbit/azimuth.git"
   },
-  "author": "",
+  "author": "Tlon",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/urbit/azimuth/issues"

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,3 @@
-// Allows us to use ES6 in migrations and tests.
-require('babel-register')
-require('babel-polyfill')
-
 module.exports = {
   networks: {
     development: {


### PR DESCRIPTION
It's desirable to be able to distribute azimuth via npm, but at present there's already an "azimuth" package using the name there.

I've prefixed azimuth with 'urbit' here, as is done for all other npm-distributed packages, but am obviously open to alternatives if for some reason anyone doesn't want to do that.  I think `urbit-azimuth` is ideal, though, probably.