### PR TITLE
Update Delegated Sending semantics

### DIFF
--- a/test/TestDelegatedSending.js
+++ b/test/TestDelegatedSending.js
@@ -37,12 +37,12 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
   });
 
   it('configuring', async function() {
-    assert.equal(await dese.pools(p1+1), 0);
+    assert.equal(await dese.pools(p1), 0);
     assert.isFalse(await dese.canSend(p1, p2));
     // can only be done by prefix star owner.
     await assertRevert(dese.setPoolSize(p1, 3, {from:user1}));
     await dese.setPoolSize(p1, 3);
-    assert.equal(await dese.pools(p1+1), 3);
+    assert.equal(await dese.pools(p1), 3);
     let inviters = await dese.getInviters();
     assert.equal(inviters.length, 1);
     assert.equal(inviters[0], p1);
@@ -58,8 +58,8 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     assert.isTrue(await dese.canReceive(user1));
     await seeEvents(dese.sendPoint(p1, p2, user1), ['Sent']);
     assert.isTrue(await azimuth.isTransferProxy(p2, user1));
-    assert.equal(await dese.pools(p1+1), 2);
-    assert.equal(await dese.fromPool(p2), p1+1);
+    assert.equal(await dese.pools(p1), 2);
+    assert.equal(await dese.fromPool(p2), p1);
     let invited = await dese.getInvited(p1);
     assert.equal(invited.length, 1);
     assert.equal(invited[0], p2);
@@ -76,15 +76,15 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     await assertRevert(dese.sendPoint(p1, p3, user1));
     // send as invited planet
     await dese.sendPoint(p2, p3, user2, {from:user1});
-    assert.equal(await dese.pools(p1+1), 1);
-    assert.equal(await dese.fromPool(p3), p1+1);
+    assert.equal(await dese.pools(p1), 1);
+    assert.equal(await dese.fromPool(p3), p1);
     invited = await dese.getInvited(p2);
     assert.equal(invited.length, 1);
     assert.equal(invited[0], p3);
     assert.equal(await dese.invitedBy(p3), p2);
     await eclipt.transferPoint(p3, user2, true);
     await dese.sendPoint(p3, p4, user3, {from:user2});
-    assert.equal(await dese.pools(p1+1), 0);
+    assert.equal(await dese.pools(p1), 0);
     await eclipt.transferPoint(p4, user3, true);
     // can't send more than the limit
     assert.isFalse(await dese.canSend(p1, p5));

--- a/test/TestDelegatedSending.js
+++ b/test/TestDelegatedSending.js
@@ -37,12 +37,15 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
   });
 
   it('configuring', async function() {
-    assert.equal(await dese.limits(256), 0);
+    assert.equal(await dese.pools(p1+1), 0);
     assert.isFalse(await dese.canSend(p1, p2));
-    // can only be done by star owner.
-    await assertRevert(dese.configureLimit(256, 1, {from:user1}));
-    await dese.configureLimit(256, 3);
-    assert.equal(await dese.limits(256), 3);
+    // can only be done by prefix star owner.
+    await assertRevert(dese.setPoolSize(p1, 3, {from:user1}));
+    await dese.setPoolSize(p1, 3);
+    assert.equal(await dese.pools(p1+1), 3);
+    let inviters = await dese.getInviters();
+    assert.equal(inviters.length, 1);
+    assert.equal(inviters[0], p1);
     assert.isTrue(await dese.canSend(p1, p2));
   });
 
@@ -55,6 +58,12 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     assert.isTrue(await dese.canReceive(user1));
     await seeEvents(dese.sendPoint(p1, p2, user1), ['Sent']);
     assert.isTrue(await azimuth.isTransferProxy(p2, user1));
+    assert.equal(await dese.pools(p1+1), 2);
+    assert.equal(await dese.fromPool(p2), p1+1);
+    let invited = await dese.getInvited(p1);
+    assert.equal(invited.length, 1);
+    assert.equal(invited[0], p2);
+    assert.equal(await dese.invitedBy(p2), p1);
     assert.isFalse(await dese.canSend(p1, p2));
     await assertRevert(dese.sendPoint(p1, p2, user1));
     // can't send to users with pending transfers
@@ -67,8 +76,15 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     await assertRevert(dese.sendPoint(p1, p3, user1));
     // send as invited planet
     await dese.sendPoint(p2, p3, user2, {from:user1});
+    assert.equal(await dese.pools(p1+1), 1);
+    assert.equal(await dese.fromPool(p3), p1+1);
+    invited = await dese.getInvited(p2);
+    assert.equal(invited.length, 1);
+    assert.equal(invited[0], p3);
+    assert.equal(await dese.invitedBy(p3), p2);
     await eclipt.transferPoint(p3, user2, true);
     await dese.sendPoint(p3, p4, user3, {from:user2});
+    assert.equal(await dese.pools(p1+1), 0);
     await eclipt.transferPoint(p4, user3, true);
     // can't send more than the limit
     assert.isFalse(await dese.canSend(p1, p5));
@@ -76,10 +92,8 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     await assertRevert(dese.sendPoint(p3, p5, user4));
   });
 
-  it('resetting a pool', async function() {
-    // can only be done by owner of the target's prefix
-    await assertRevert(dese.resetPool(p3, {from:user1}));
-    await dese.resetPool(p3);
+  it('resetting an invitee\'s pool', async function() {
+    await dese.setPoolSize(p3, 3);
     assert.isTrue(await dese.canSend(p3, p5));
     // shouldn't affect the pool it came from
     assert.isFalse(await dese.canSend(p1, p5));


### PR DESCRIPTION
This PR makes changes exclusively to secondary contracts. It does not touch the core contracts (Azimuth & Ecliptic) and as such does not involve the Senate.

- Instead of stars setting a star-wide pool size for all their not-via-invite plants, they now set per-planet pool sizes explicitly.
- The contract now keeps track of invite trees within its own state. You can look up invite tree roots, the points they invited, and who the inviter is for any given point.

Arguably, the "register as invite tree root" code should be done when a point first calls `sendPoint`, rather than when the star calls `setPoolSize` for it, to prevent registering invite tree roots that don't have any points under them. The check for that in `sendPoint` would get a bit ugly though, so I have kept it in `sendPoint` for now.

I also want to update the logic to no longer do the "planet number + 1" thing for pool numbers. I think we did that because technically `0` is a valid point, and so the default of `0` could get confusing. I don't agree with that, and feel we should ditch the "~zod has a pool" case in favor of simpler code. @philipcmonk what do you think?

cc @alexmatz