### PR TITLE
Make getPool() public, auto-deploy DelegatedSending

### DIFF
--- a/contracts/DelegatedSending.sol
+++ b/contracts/DelegatedSending.sol
@@ -178,7 +178,7 @@ contract DelegatedSending is ReadsAzimuth
   //  getPool(): get the invite pool _point belongs to
   //
   function getPool(uint32 _point)
-    internal
+    public
     view
     returns (uint32 pool)
   {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,6 +3,7 @@ var Polls = artifacts.require("./Polls.sol");
 var Claims = artifacts.require("./Claims.sol");
 var Censures = artifacts.require("./Censures.sol");
 var Ecliptic = artifacts.require("./Ecliptic.sol");
+var DelegatedSending = artifacts.require("./DelegatedSending.sol");
 
 module.exports = async function(deployer) {
   // deployer.deploy([Azimuth, Polls]);
@@ -56,6 +57,9 @@ module.exports = async function(deployer) {
     var own = await ecliptic.owner();
     console.log('remember owner ' + own);
     console.log('of ecliptic ' + ecliptic.address);
+  }).then(function() {
+    return deployer.deploy(DelegatedSending, azimuth.address);
+  }).then(function() {
     // await ecliptic.createGalaxy(0, own);
     // await ecliptic.configureKeys(0, 123, 456, 1, false);
     // await ecliptic.spawn(256, own);


### PR DESCRIPTION
There's really no reason for this to be internal only. Having to rewrite this little bit of logic on the client side is dumb.

@jtobin, would you be so kind as to sign off on this change (if it lgty), and then push a new version of azimuth-solidity to npm? (: