### PR TITLE
Support DelegatedSending invites from arbitrary stars

### DIFF
--- a/test/TestDelegatedSending.js
+++ b/test/TestDelegatedSending.js
@@ -7,16 +7,19 @@ const DelegatedSending = artifacts.require('../contracts/DelegatedSending.sol');
 const assertRevert = require('./helpers/assertRevert');
 const seeEvents = require('./helpers/seeEvents');
 
-contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
+contract('Delegated Sending', function([owner, user1, user2, user3, user4, user5]) {
   let azimuth, eclipt, dese;
   let p1, p2, p3, p4, p5;
 
   before('setting up for tests', async function() {
+    s1 = 256;
+    s2 = 512;
     p1 = 65792;
     p2 = 131328;
     p3 = 196864;
     p4 = 262400;
     p5 = 327936;
+    p6 = 66048;
     //
     azimuth = await Azimuth.new();
     polls = await Polls.new(432000, 432000);
@@ -29,20 +32,29 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     //
     await eclipt.createGalaxy(0, owner);
     await eclipt.configureKeys(0, 1, 1, 1, false);
-    await eclipt.spawn(256, owner);
-    await eclipt.configureKeys(256, 1, 1, 1, false);
+    await eclipt.spawn(s1, owner);
+    await eclipt.configureKeys(s1, 1, 1, 1, false);
+    await eclipt.setSpawnProxy(s1, dese.address);
+    await eclipt.spawn(s2, owner);
+    await eclipt.configureKeys(s2, 1, 1, 1, false);
+    await eclipt.setSpawnProxy(s2, dese.address);
     await eclipt.spawn(p1, owner);
     await eclipt.transferPoint(p1, owner, false);
-    await eclipt.setSpawnProxy(256, dese.address);
   });
 
   it('configuring', async function() {
-    assert.equal(await dese.pools(p1), 0);
+    assert.equal(await dese.pools(p1, s1), 0);
     assert.isFalse(await dese.canSend(p1, p2));
-    // can only be done by prefix star owner.
-    await assertRevert(dese.setPoolSize(p1, 3, {from:user1}));
-    await dese.setPoolSize(p1, 3);
-    assert.equal(await dese.pools(p1), 3);
+    // can only be done by owner of any star
+    await assertRevert(dese.setPoolSize(s1, p1, 3, {from:user1}));
+    await dese.setPoolSize(s1, p1, 3);
+    await dese.setPoolSize(s2, p1, 9);
+    let poolStars = await dese.getPoolStars(p1);
+    assert.equal(poolStars.length, 2);
+    assert.equal(poolStars[0], s1);
+    assert.equal(poolStars[1], s2);
+    assert.equal(await dese.pools(p1, s1), 3);
+    assert.equal(await dese.pools(p1, s2), 9);
     let inviters = await dese.getInviters();
     assert.equal(inviters.length, 1);
     assert.equal(inviters[0], p1);
@@ -58,7 +70,7 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     assert.isTrue(await dese.canReceive(user1));
     await seeEvents(dese.sendPoint(p1, p2, user1), ['Sent']);
     assert.isTrue(await azimuth.isTransferProxy(p2, user1));
-    assert.equal(await dese.pools(p1), 2);
+    assert.equal(await dese.pools(p1, s1), 2);
     assert.equal(await dese.fromPool(p2), p1);
     let invited = await dese.getInvited(p1);
     assert.equal(invited.length, 1);
@@ -75,28 +87,35 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     assert.isFalse(await dese.canReceive(user1));
     await assertRevert(dese.sendPoint(p1, p3, user1));
     // send as invited planet
+    assert.equal(await dese.getPool(p3), p3);
     await dese.sendPoint(p2, p3, user2, {from:user1});
-    assert.equal(await dese.pools(p1), 1);
+    assert.equal(await dese.pools(p1, s1), 1);
     assert.equal(await dese.fromPool(p3), p1);
+    assert.equal(await dese.getPool(p3), p1);
     invited = await dese.getInvited(p2);
     assert.equal(invited.length, 1);
     assert.equal(invited[0], p3);
     assert.equal(await dese.invitedBy(p3), p2);
     await eclipt.transferPoint(p3, user2, true);
     await dese.sendPoint(p3, p4, user3, {from:user2});
-    assert.equal(await dese.pools(p1), 0);
+    assert.equal(await dese.pools(p1, s1), 0);
     await eclipt.transferPoint(p4, user3, true);
-    // can't send more than the limit
+    // can't send once pool depleted
     assert.isFalse(await dese.canSend(p1, p5));
     assert.isFalse(await dese.canSend(p3, p5));
     await assertRevert(dese.sendPoint(p3, p5, user4));
+    // but can still send from other pool, even as invitee
+    assert.isTrue(await dese.canSend(p1, p6));
+    assert.isTrue(await dese.canSend(p3, p6));
+    await dese.sendPoint(p3, p6, user4, {from:user2});
+    assert.equal(await dese.pools(p1, s2), 8);
   });
 
   it('resetting an invitee\'s pool', async function() {
-    await dese.setPoolSize(p3, 3);
+    await dese.setPoolSize(s1, p3, 3);
     assert.isTrue(await dese.canSend(p3, p5));
     // shouldn't affect the pool it came from
     assert.isFalse(await dese.canSend(p1, p5));
-    await dese.sendPoint(p3, p5, user4, {from:user2});
+    await dese.sendPoint(p3, p5, user5, {from:user2});
   });
 });


### PR DESCRIPTION
Currently, stars can only give invites to their child planets. Since most early adopters (among who many star owners) own/use planets somewhere under ~zod, this makes them unable to send out invites as themselves. Instead, they must manually spawn a planet to whoever they want to give invites to, and only from there build out invite trees.

In this PR, we change the logic in the contract to allow planets receiving invites from any amount of arbitrary stars, rather than just their prefix.

The `pools` `mapping(uint32 => uint16)` becomes a `mapping(uint32 => mapping(uint16 => uint16))`, and we add in both a `mapping(uint32 => uint16[]) poolStars` and a `mapping(uint32 => mapping(uint16 => bool)) poolStarsRegistered` to aid in discovering and managing that data respectively.

It remains up to client implementations to discover planets that are eligible for sending. This is a bit more work than it used to be, but isn't the end of the world. I will add functionality for this into azimuth-js soon.