### PR TITLE
Document proposal 0x000...0a0: Arvo is stable

### DIFF
--- a/proposals/0x00000000000000000000000000000000000000000000000000000000000000a0.txt
+++ b/proposals/0x00000000000000000000000000000000000000000000000000000000000000a0.txt
@@ -1,0 +1,1 @@
+Tlon has designated Arvo (the Urbit operating system, as described at https://urbit.org/docs/arvo/internals/) as "stable".


### PR DESCRIPTION
Note that the hash for this proposal does not match its contents, as described in `0xcb1f81e42b5e75f000f94fc71a3ea70cab4bfc6f236b91e717f1b9516e5596b5`.

https://github.com/urbit/azimuth/blob/edf68b8da04806dd5b95994daf14cf1e7e226829/proposals/0xcb1f81e42b5e75f000f94fc71a3ea70cab4bfc6f236b91e717f1b9516e5596b5.txt#L1

Perhaps mention of that should be included in the `.txt` itself. Happy to amend if that's desired.