### PR TITLE
Document proposal 0x000...060: Azimuth is live

### DIFF
--- a/proposals/0x0000000000000000000000000000000000000000000000000000000000000060.txt
+++ b/proposals/0x0000000000000000000000000000000000000000000000000000000000000060.txt
@@ -1,0 +1,1 @@
+Azimuth and Ecliptic are live on the Ethereum blockchain and comprise the Urbit Constitution.


### PR DESCRIPTION
This document achieved majority [nearly a year ago](https://etherscan.io/tx/0xcd7756da0dda6bec73b1d7fb3b1af390d8e87e847da19f8d50460272de4139ca#eventlog).

This PR adds it to the repository as a `.txt`, so that we have it properly documented. Bridge tries linking to it, but currently 404s.

Note that the hash for this proposal does not match its contents, as described in `0xcb1f81e42b5e75f000f94fc71a3ea70cab4bfc6f236b91e717f1b9516e5596b5`.

https://github.com/urbit/azimuth/blob/edf68b8da04806dd5b95994daf14cf1e7e226829/proposals/0xcb1f81e42b5e75f000f94fc71a3ea70cab4bfc6f236b91e717f1b9516e5596b5.txt#L1