### PR TITLE
emit ClaimRemoved events while clearing claims

### DIFF
--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -145,6 +145,8 @@ contract Claims is ReadsAzimuth
     //
     for (uint8 i = 0; i < maxClaims; i++)
     {
+      emit ClaimRemoved(_point, currClaims[i].protocol, currClaims[i].claim);
+
       delete currClaims[i];
     }
   }


### PR DESCRIPTION
I noticed that we're not emitting `ClaimRemoved` events when clearing claims, so this fixes that.