### PR TITLE
ecliptic: wstr contract hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is just a quick summary of the different contracts and their purposes. For 
 The core Azimuth contracts can be found on the Ethereum blockchain.
 
 * **Azimuth**: [azimuth.eth / `0x223c067f8cf28ae173ee5cafea60ca44c335fecb`](https://etherscan.io/address/azimuth.eth)
-* **Ecliptic**: [ecliptic.eth / `0x9ef27de616154FF8B38893C59522b69c7Ba8A81c`](https://etherscan.io/address/ecliptic.eth)
+* **Ecliptic**: [ecliptic.eth / `0x33eecbf908478c10614626a9d304bfe18b78dd73`](https://etherscan.io/address/ecliptic.eth)
 * **Polls**: [`0x7fecab617c868bb5996d99d95200d2fa708218e4`](https://etherscan.io/address/0x7fecab617c868bb5996d99d95200d2fa708218e4)
 * **Linear Star Release**: [`0x86cd9cd0992f04231751e3761de45cecea5d1801`](https://etherscan.io/address/0x86cd9cd0992f04231751e3761de45cecea5d1801)
 * **Conditional Star Release**: [`0x8c241098c3d3498fe1261421633fd57986d74aea`](https://etherscan.io/address/0x8c241098c3d3498fe1261421633fd57986d74aea)

--- a/contracts/interfaces/ITreasuryProxy.sol
+++ b/contracts/interfaces/ITreasuryProxy.sol
@@ -1,0 +1,7 @@
+pragma solidity >=0.4 <0.9;
+
+interface ITreasuryProxy {
+  function upgradeTo(address _impl) external returns (bool);
+
+  function freeze() external returns (bool);
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -39,7 +39,8 @@ module.exports = async function(deployer, network, accounts) {
     "0x0000000000000000000000000000000000000000",
     azimuth.address,
     polls.address,
-    claims.address
+    claims.address,
+    "0x0000000000000000000000000000000000000000"
   );
 
   // configure contract ownership

--- a/test-extras/TestEclipticUpgrade.js
+++ b/test-extras/TestEclipticUpgrade.js
@@ -43,7 +43,7 @@ contract('Ecliptic', function() {
     if (nuEclipticAddr) {
       nuEcliptic = await Ecliptic.at(nuEclipticAddr);
     } else {
-      nuEcliptic = await Ecliptic.new(eclipticAddr, azimuthAddr, pollsAddr, claimsAddr);
+      nuEcliptic = await Ecliptic.new(eclipticAddr, azimuthAddr, pollsAddr, claimsAddr, '0x0000000000000000000000000000000000000000');
       nuEclipticAddr = nuEcliptic.address;
     }
     console.log('new ecliptic at', nuEclipticAddr);
@@ -83,7 +83,7 @@ contract('Ecliptic', function() {
   });
 
   it('can still upgrade', async function () {
-    const third = await Ecliptic.new(nuEclipticAddr, azimuthAddr, pollsAddr, await nuEcliptic.claims());
+    const third = await Ecliptic.new(nuEclipticAddr, azimuthAddr, pollsAddr, await nuEcliptic.claims(), '0x0000000000000000000000000000000000000000');
     await nuEcliptic.startUpgradePoll(0, third.address, {
       from: senators[0],
       gasPrice: 0


### PR DESCRIPTION
This upgrade was voted in on 2021-11-27. For detailed context, see:
https://groups.google.com/a/urbit.org/g/dev/c/zF7OQQeHW6U

In short, this was used to mitigate a security vulnerability in a
secondary contract.