### PR TITLE
fix: move truffle compiler config settings

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -14,9 +14,11 @@ module.exports = {
   compilers: {
     solc: {
       version: "pragma",
-      optimizer: {
-        enabled: true,
-        runs: 200
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 200
+        }
       }
     }
   },


### PR DESCRIPTION
**Problem:**
The compiler settings were in the wrong place, so the contracts weren't compiling with the optimizer and were therefore oversized, preventing them from being deployed.

**Fix:**
Moved the settings according to the [truffle docs](https://trufflesuite.com/docs/truffle/reference/configuration/#compiler-configuration)

**Notes**

Tests still seem broken, so not finished with #62 but this does fix deployments.

This should also help with urbit/bridge#1106